### PR TITLE
Helper Function Rewrite

### DIFF
--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -6,69 +6,77 @@
 #include <cstdio>
 #include <iostream>
 #include <cstring>
+#include <filesystem>
+
+namespace fs = std::filesystem;
 
 std::string randomString(int length) {
-    static auto& characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+	static auto& characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-    thread_local static std::mt19937 rg{std::random_device{}()};
-    thread_local static std::uniform_int_distribution<std::string::size_type> pick(0, sizeof(characters) - 2);
+	thread_local static std::mt19937 rg{std::random_device{}()};
+	thread_local static std::uniform_int_distribution<std::string::size_type> pick(0, sizeof(characters) - 2);
 
-    std::string s;
-    s.reserve(length);
+	std::string s;
+	s.reserve(length);
 
-    for (int i = 0; i < length; i++) {
-        s += characters[pick(rg)];
-    }
+	for (int i = 0; i < length; i++) {
+		s += characters[pick(rg)];
+	}
 
-    return s;
+	return s;
 }
 
 bool fileExists(const std::string& path) {
-    std::ifstream stream(path);
-    return stream.good();
+	std::ifstream stream(path);
+	return stream.good();
 }
 
-std::string readFile(const std::string& path) {
-    std::ifstream stream(path);
-    std::stringstream buffer;
-    buffer << stream.rdbuf();
-    std::string content = buffer.str();
-    stream.close();
-    content.erase(std::remove(content.begin(), content.end(), '\r'), content.end());
-    content.erase(std::remove(content.begin(), content.end(), '\n'), content.end());
-
-    return content;
+void readFile(const std::string& path, std::string& contents) {
+	std::ifstream file(path);
+	const uintmax_t fileSize = fs::file_size(path);
+	contents.reserve(static_cast<size_t>(fileSize));
+	contents.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+	contents.erase(std::remove(contents.begin(), contents.end(), '\r'), contents.end());
+	contents.erase(std::remove(contents.begin(), contents.end(), '\n'), contents.end());
+	file.close();
 }
 
 void writeFile(const std::string& name, const std::string& content) {
-    std::ofstream outfile(name);
-    outfile << content;
-    outfile.close();
+	std::ofstream outfile(name);
+	outfile << content;
+	outfile.close();
 }
 
+/*
+	will only remove a file, if a intermediate directory is passed it will fail, could use
+	remove_all and it will remove not only the intermediate directory but also it's sub files
+	return types:
+		remove		= boolean
+		remove_all	= uintmax_t
+*/
 bool deleteFile(const std::string& name) {
-    return std::remove(name.c_str()) == 0;
+	return fs::remove(name);
 }
 
 std::array<char, HASH_LENGTH> convertHash(const std::string& hash) {
-    if (hash.size() != HASH_LENGTH) {
-        std::cerr << "Invalid string when converting hash..." << std::endl;
-        return {};
-    }
+	if (hash.size() != HASH_LENGTH) {
+		std::cerr << "Invalid string when converting hash..." << std::endl;
+		return {};
+	}
 
-    std::array<char, HASH_LENGTH> value {};
-    const char* characters = hash.data();
-    for (int i = 0; i < HASH_LENGTH; i++) {
-        value[i] = characters[i];
-    }
+	std::array<char, HASH_LENGTH> value {};
+	const char* characters = hash.data();
+	for (int i = 0; i < HASH_LENGTH; i++) {
+		value[i] = characters[i];
+	}
 
-    return value;
+	return value;
 }
 
 std::string print(std::array<char, HASH_LENGTH> hash) {
-    std::string stringified;
-    stringified.reserve(HASH_LENGTH);
-    std::memcpy(stringified.data(), hash.data(), HASH_LENGTH);
+	std::string stringified;
+	stringified.reserve(HASH_LENGTH);
+	std::memcpy(stringified.data(), hash.data(), HASH_LENGTH);
 
-    return stringified;
+	return stringified;
 }

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -26,7 +26,7 @@ std::string randomString(int length);
 
 bool fileExists(const std::string& path);
 
-std::string readFile(const std::string& path);
+void readFile(const std::string& path, std::string& contents);
 
 void writeFile(const std::string& name, const std::string& content);
 

--- a/src/KeyManager.cpp
+++ b/src/KeyManager.cpp
@@ -9,10 +9,10 @@ KeyManager::KeyManager() {
 
 void KeyManager::refreshKeys() {
     std::vector<AccessKeys> keys;
-
+    std::string contents;
     for (const auto& entry : std::filesystem::directory_iterator("../keys")) {
         std::string filename = entry.path().string();
-        std::string contents = readFile(filename);
+        readFile(filename, contents);
         if (contents.length() != HASH_LENGTH * 2 + 1) {
             std::cerr << "Reading hash file with incorrect contents... " << filename << std::endl;
             continue;
@@ -30,6 +30,7 @@ void KeyManager::refreshKeys() {
                 moonKey,
                 playerKey
         });
+        contents.clear();
     }
 
     const std::lock_guard<std::mutex> keyLock(m_keyMutex);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,9 @@
 static_assert(sizeof(char) == 1, "Character size must be 1 byte.");
 
 int main() {
-    const std::string secret = readFile("../secretkey.txt");
+    std::string contents;
+    readFile("../secretkey.txt", contents);
+    const std::string secret = contents;
 
     KeyManager keyManager;
     RoomManager roomManager;


### PR DESCRIPTION
Helpers:
- rewrote readFile to pass the string to store the data by reference so garbage collection doesn't need to be preform each time the function is called as it moves out of scope.
- rewrote deleteFile to use the filesystem remove function as it's return type is boolean, and added comments for if remove_all is a more desired function.

KeyManager:
- fixed the error from the readFile being rewritten and moved the string declaraction outside the for loop so memory is not allocated each time the loop executes, call clear at the end of the loop to hope that the allocated memory contents of the previous file don't mess with the next.

main:
- made the const secret uglier because the readFile function no longer returns a copy, but preserved the const variable.